### PR TITLE
feat(editor): Improve editor startup error messages + document editor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ Files containing only whitespace changes remain listed because Git still conside
 
 `show_line_numbers` controls whether line numbers are shown in the diff view at startup. It defaults to `true`. Press `L` while Marten is running to toggle it.
 
+### Editor
+
+Pressing `e` in the diff view opens the current line in your editor. Marten uses `$VISUAL`, falls back to `$EDITOR`, and finally to `vi`. Set it in your shell profile (`~/.zshrc`, `~/.bashrc`):
+
+```bash
+export EDITOR='nvim'
+```
+
+The value must be a plain executable available in your `PATH`:
+
+- Shell aliases and functions don't work: Marten runs the editor directly, without a shell, so an alias like `alias vim=nvim` is invisible to it.
+- Arguments aren't supported: `EDITOR='code -w'` is treated as a single command name and fails to launch.
+- The `vi` fallback only works if `vi` is actually installed.
+
 ## Development
 
 ```bash

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5,11 +5,25 @@ enum LineArg {
     Colon,
 }
 
-pub fn command(path: &Path, line: usize) -> Command {
-    command_for(&resolve_editor(), path, line)
+#[derive(Debug)]
+pub enum Source {
+    Variable(&'static str),
+    Fallback,
 }
 
-fn command_for(editor: &str, path: &Path, line: usize) -> Command {
+pub fn resolve() -> (String, Source) {
+    for variable in ["VISUAL", "EDITOR"] {
+        if let Ok(editor) = env::var(variable) {
+            if !editor.trim().is_empty() {
+                return (editor, Source::Variable(variable));
+            }
+        }
+    }
+
+    ("vi".into(), Source::Fallback)
+}
+
+pub fn command(editor: &str, path: &Path, line: usize) -> Command {
     let mut cmd = Command::new(editor);
 
     match line_arg_style(editor) {
@@ -21,12 +35,6 @@ fn command_for(editor: &str, path: &Path, line: usize) -> Command {
         }
     }
     cmd
-}
-
-fn resolve_editor() -> String {
-    env::var("VISUAL")
-        .or_else(|_| env::var("EDITOR"))
-        .unwrap_or_else(|_| "vi".into())
 }
 
 fn line_arg_style(editor: &str) -> LineArg {

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,11 @@ pub enum AppError {
         operation: &'static str,
         source: std::io::Error,
     },
+    Editor {
+        editor: String,
+        origin: crate::editor::Source,
+        source: std::io::Error,
+    },
 }
 
 pub type AppResult<T> = Result<T, AppError>;
@@ -32,6 +37,18 @@ pub type AppResult<T> = Result<T, AppError>;
 impl AppError {
     pub const fn git(operation: &'static str, source: git2::Error) -> Self {
         Self::Git { operation, source }
+    }
+
+    pub const fn editor(
+        editor: String,
+        origin: crate::editor::Source,
+        source: std::io::Error,
+    ) -> Self {
+        Self::Editor {
+            editor,
+            origin,
+            source,
+        }
     }
 
     pub fn with_operation(self, operation: &'static str) -> Self {
@@ -97,6 +114,24 @@ impl std::fmt::Display for AppError {
             Self::Io { operation, source } => {
                 write!(formatter, "could not {operation}: {source}")
             }
+            Self::Editor {
+                editor,
+                origin,
+                source,
+            } if source.kind() == std::io::ErrorKind::NotFound => match origin {
+                crate::editor::Source::Fallback => write!(
+                    formatter,
+                    "could not open editor: $VISUAL and $EDITOR are not set and the fallback \
+                     '{editor}' was not found in PATH"
+                ),
+                crate::editor::Source::Variable(variable) => write!(
+                    formatter,
+                    "could not open editor: '{editor}' from ${variable} was not found in PATH"
+                ),
+            },
+            Self::Editor { editor, source, .. } => {
+                write!(formatter, "could not open editor '{editor}': {source}")
+            }
         }
     }
 }
@@ -110,7 +145,7 @@ impl std::error::Error for AppError {
             | Self::RevisionNotCommit { source, .. }
             | Self::Git { source, .. } => Some(source),
             Self::InvalidRange { .. } => None,
-            Self::Io { source, .. } => Some(source),
+            Self::Io { source, .. } | Self::Editor { source, .. } => Some(source),
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -120,11 +120,10 @@ fn run_loop(
                         }
                         disable_raw_mode()?;
                         execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
-                        editor::command(&path, line as usize)
+                        let (program, origin) = editor::resolve();
+                        editor::command(&program, &path, line as usize)
                             .status()
-                            .map_err(|source| {
-                                AppError::from(source).with_operation("open editor")
-                            })?;
+                            .map_err(|source| AppError::editor(program, origin, source))?;
 
                         execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
                         enable_raw_mode()?;


### PR DESCRIPTION
**Summary:**
- The error shown when the editor cannot be started is now more detailed; if the editor binary is not found, it is reported as a PATH lookup failure. Any other failure (permission, for example) keeps the original system error.

Error messages:
> marten: could not open editor: 'nvim' from $EDITOR was not found in PATH

> marten: could not open editor: $VISUAL and $EDITOR are not set and the fallback 'vi' was not found in PATH

> marten: could not open editor 'nvim': Permission denied (os error 13)

- A section was added to the README to document the Editor settings.

_Translate by DeepSeek_

---

**PT-BR**

**Resumo:**
- O erro exibido quando o editor não pode ser iniciado agora é mais detalhado; se o binário do editor não for encontrado, ele é reportado como uma falha na busca do PATH. Qualquer outra falha (permissão, por exemplo) mantém o erro original do sistema.

Mensagens de erro:
> marten: could not open editor: 'nvim' from $EDITOR was not found in PATH

> marten: could not open editor: $VISUAL and $EDITOR are not set and the fallback 'vi' was not found in PATH

> marten: could not open editor 'nvim': Permission denied (os error 13)

- Foi adicionada uma seção no README para documentar as configurações do Editor.

refs #3 